### PR TITLE
Scale down typography on mobile (≤640px)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1964,4 +1964,211 @@
     padding-top: 1.4rem;
     padding-bottom: 1.8rem;
   }
+
+  /* Mobile typography scale-down */
+  .navbar__title {
+    font-size: 1.05rem;
+  }
+
+  .hero-section h1 {
+    font-size: 2.4rem !important;
+    line-height: 1.05 !important;
+  }
+
+  .hero-description {
+    font-size: 0.85rem !important;
+    line-height: 1.7 !important;
+  }
+
+  .hero-pill {
+    font-size: 0.5rem;
+  }
+
+  .brand-title {
+    font-size: clamp(1.6rem, 6vw, 2.4rem);
+    line-height: 1.1;
+  }
+
+  .brand-eyebrow {
+    font-size: 0.66rem;
+    letter-spacing: 0.16em;
+  }
+
+  .brand-copy,
+  .brand-lead {
+    font-size: 0.9rem;
+    line-height: 1.75;
+  }
+
+  .partner-strip__title,
+  .field-record-strip__title {
+    font-size: clamp(1.1rem, 4.4vw, 1.4rem);
+  }
+
+  .partner-strip__copy,
+  .field-record-strip__copy {
+    font-size: 0.88rem;
+    line-height: 1.7;
+  }
+
+  .field-record-card__caption strong {
+    font-size: 0.9rem;
+  }
+
+  .field-record-card__caption span {
+    font-size: 0.76rem;
+  }
+
+  .capability-summary-title {
+    font-size: clamp(1.5rem, 6vw, 2.1rem);
+    line-height: 1.08;
+  }
+
+  .capability-summary-intro {
+    font-size: 0.95rem;
+    line-height: 1.7;
+  }
+
+  .capability-summary-copy {
+    font-size: 0.9rem;
+    line-height: 1.8;
+  }
+
+  .capability-feature-card__title {
+    font-size: clamp(1.05rem, 4.4vw, 1.3rem);
+  }
+
+  .capability-feature-card__copy {
+    font-size: 0.88rem;
+    line-height: 1.75;
+  }
+
+  .capability-item__label {
+    font-size: 0.7rem;
+  }
+
+  .capability-item__value {
+    font-size: clamp(0.95rem, 3.6vw, 1.15rem);
+  }
+
+  .product-card__name {
+    font-size: clamp(1.5rem, 6vw, 2rem);
+  }
+
+  .product-card__type {
+    font-size: 0.88rem;
+  }
+
+  .product-card__summary {
+    font-size: 0.9rem;
+    line-height: 1.75;
+  }
+
+  .product-card__kicker,
+  .product-card__cta {
+    font-size: 0.68rem;
+  }
+
+  .product-card__meta {
+    font-size: 0.72rem;
+  }
+
+  .contact-checklist__title {
+    font-size: 0.98rem;
+  }
+
+  .contact-checklist__item p {
+    font-size: 0.88rem;
+    line-height: 1.7;
+  }
+
+  .editorial-nameplate__title {
+    font-size: clamp(2.2rem, 10vw, 3.4rem);
+  }
+
+  .editorial-nameplate__tagline {
+    font-size: 0.85rem;
+  }
+
+  .editorial-lead-story__headline,
+  .editorial-article__headline {
+    font-size: clamp(2rem, 8vw, 3rem);
+  }
+
+  .editorial-lead-story__deck {
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+
+  .editorial-lead-story__body {
+    font-size: 0.9rem;
+    line-height: 1.75;
+  }
+
+  .editorial-brief__title,
+  .editorial-article__title,
+  .editorial-contact-lead__headline {
+    font-size: clamp(1.3rem, 5vw, 1.85rem);
+  }
+
+  .editorial-brief__body,
+  .editorial-article__body,
+  .editorial-factbox__note,
+  .editorial-section-title-wrap p {
+    font-size: 0.9rem;
+    line-height: 1.75;
+  }
+
+  .editorial-section-title-wrap h2 {
+    font-size: clamp(1.9rem, 8vw, 2.8rem);
+  }
+
+  .editorial-email,
+  .editorial-contact-email {
+    font-size: clamp(1.25rem, 5.5vw, 1.9rem);
+  }
+
+  .editorial-factbox__item strong {
+    font-size: 1.15rem;
+  }
+
+  .onepage-title,
+  .onepage-title--compact {
+    font-size: clamp(1.85rem, 7vw, 2.8rem);
+    line-height: 1.05;
+  }
+
+  .onepage-lead {
+    font-size: 0.98rem;
+    line-height: 1.75;
+  }
+
+  .onepage-body {
+    font-size: 0.9rem;
+    line-height: 1.75;
+  }
+
+  .onepage-stat-value {
+    font-size: 1.02rem;
+  }
+
+  .onepage-feature-title {
+    font-size: clamp(1.2rem, 4.8vw, 1.55rem);
+  }
+
+  .onepage-feature-copy {
+    font-size: 0.9rem;
+    line-height: 1.75;
+  }
+
+  .onepage-email-link {
+    font-size: clamp(1.5rem, 7vw, 2.5rem);
+  }
+
+  .onepage-eyebrow,
+  .onepage-subhead,
+  .onepage-marker span,
+  .onepage-stat-label {
+    font-size: 0.66rem;
+  }
 }


### PR DESCRIPTION
Adds targeted font-size overrides for navbar, hero, brand, capability, product, contact, editorial, and onepage typography classes so mobile display feels less oversized.