### PR TITLE
Add GitHub Pages deploy job to CI/CD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,7 +11,7 @@ on:
       - dev
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -32,6 +32,38 @@ jobs:
 
       - name: Build site
         run: npm run build
+
+      - name: Upload site build artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-build
+          path: build/
+          retention-days: 7
+
+  deploy-pages:
+    runs-on: ubuntu-latest
+    needs: site-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download site build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-build
+          path: build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./build
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
+          commit_message: "Deploy ${{ github.sha }}"
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a deploy-pages job that runs on github-hosted ubuntu-latest, downloads the site-build artifact, and pushes it to the gh-pages branch so www.dataisland.tw updates automatically on push to main.

Self-hosted runner docker deploy path is left unchanged for the secondary environment.