### PR TITLE
Fix hero title overflow and pill banner on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1999,8 +1999,10 @@
   }
 
   .hero-section h1 {
-    font-size: 2.4rem !important;
-    line-height: 1.05 !important;
+    font-size: clamp(1.55rem, 7vw, 2.1rem) !important;
+    line-height: 1.08 !important;
+    letter-spacing: -0.03em !important;
+    overflow-wrap: anywhere;
   }
 
   .hero-description {
@@ -2009,7 +2011,20 @@
   }
 
   .hero-pill {
-    font-size: 0.5rem;
+    display: inline-flex;
+    max-width: 100%;
+    padding: 0.3rem 0.55rem;
+    border-radius: 0.5rem;
+    font-size: 0.46rem;
+    letter-spacing: 0.08em;
+    line-height: 1.45;
+    word-break: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .hero-section .hero-surface {
+    padding-top: 2rem;
+    padding-bottom: 2.5rem;
   }
 
   .brand-title {


### PR DESCRIPTION
- Scale hero h1 with clamp(1.55rem, 7vw, 2.1rem) so 11-char Chinese lines fit inside narrow viewports without overflowing
- Tighten hero pill (smaller font, less letter-spacing, smaller padding) so the English tagline doesn't stretch into a banner
- Trim hero-surface vertical padding on mobile