### PR TITLE
Unify hero title sizing with product detail pages

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1603,6 +1603,7 @@
 
 /* CJK-aware line breaks for headings: keep Chinese words intact, wrap at punctuation */
 .hero-section h1,
+.inner-page-hero h1,
 .brand-title,
 .partner-strip__title,
 .field-record-strip__title,
@@ -1626,7 +1627,7 @@
 .editorial-section-title-wrap h2,
 .editorial-factbox__item strong {
   word-break: keep-all;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 @keyframes heroPolygonFloat {
@@ -1996,13 +1997,6 @@
   /* Mobile typography scale-down */
   .navbar__title {
     font-size: 1.05rem;
-  }
-
-  .hero-section h1 {
-    font-size: clamp(1.55rem, 7vw, 2.1rem) !important;
-    line-height: 1.08 !important;
-    letter-spacing: -0.03em !important;
-    overflow-wrap: anywhere;
   }
 
   .hero-description {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,8 +48,6 @@ function SectionIntro({
 }
 
 export default function Home() {
-  const mobileHeroTitleLines = hero.titleLines || [hero.title];
-  const desktopHeroTitleLines = hero.titleLines || [hero.title];
   const heroPhotoSrc = useBaseUrl('/img/camera/leopard-cat-hero.png');
   const fieldPhotos = [
     {
@@ -102,16 +100,9 @@ export default function Home() {
                   </div>
 
                   <div className="space-y-5">
-                    <h1 className="max-w-6xl text-5xl font-black leading-[0.9] tracking-[-0.05em] text-black sm:text-6xl md:hidden">
-                      {mobileHeroTitleLines.map((line) => (
+                    <h1 className="max-w-6xl text-4xl font-black leading-[1.08] tracking-[-0.05em] text-black md:text-5xl lg:text-6xl">
+                      {(hero.titleLines || [hero.title]).map((line) => (
                         <span key={line} className="block">
-                          {line}
-                        </span>
-                      ))}
-                    </h1>
-                    <h1 className="hidden max-w-6xl font-black leading-[0.9] tracking-[-0.05em] text-black md:block md:text-7xl lg:whitespace-nowrap xl:text-[5.1rem]">
-                      {desktopHeroTitleLines.map((line) => (
-                        <span key={line} className="hero-title-line">
                           {line}
                         </span>
                       ))}


### PR DESCRIPTION
- Consolidate the dual mobile/desktop hero h1 into one element using the same Tailwind sizes as the product detail pages (text-4xl md:text-5xl lg:text-6xl)
- Drop the .hero-section h1 font-size override so Tailwind drives it
- Apply CJK word-break rules to the product detail h1 too, and switch overflow-wrap to anywhere for stronger fallback on narrow viewports